### PR TITLE
Added support for void type

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,12 @@ exports_files(
 )
 
 alias(
+    name = "types",
+    actual = "//cppschema/common:types",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "visitor_macros",
     actual = "//cppschema/common:visitor_macros",
     visibility = ["//visibility:public"],

--- a/cppschema/apispec/BUILD.bazel
+++ b/cppschema/apispec/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
         "api_registry.h",
     ],
     deps = [
+        "//cppschema/common:types",
         "//cppschema/common:visitor_macros",
     ],
 )

--- a/cppschema/apispec/api_framework.h
+++ b/cppschema/apispec/api_framework.h
@@ -4,16 +4,16 @@
 #include <functional>
 #include <vector>
 
+#include "cppschema/common/types.h"
 #include "cppschema/common/visitor_macros.h"
 
 namespace cppschema {
 
+// This is an empty struct used to convery the types.
 template <typename Req, typename Res>
 struct ApiStub {
     using RequestType = Req;
     using ResponseType = Res;
-    const char* name = nullptr;
-    void* impl = nullptr;  // Pointer to the actual implementation, can be set by the backend.
 };
 
 // Base class for backends to identify themselves

--- a/cppschema/apispec/api_registry.h
+++ b/cppschema/apispec/api_registry.h
@@ -48,9 +48,6 @@ public:
         assert(backend_instance_ != nullptr && "Backend not set");
         auto it = dispatchers_.find(name);
         assert(it != dispatchers_.end() && "Method not implemented");
-        // if (it == dispatchers_.end()) {
-        //     throw std::runtime_error("Method not implemented: " + name);
-        // }
         void* rawRes = it->second(static_cast<const void*>(&req));
         // Cast back to the expected type and clean up the heap-allocated response
         Res* typedRes = static_cast<Res*>(rawRes);

--- a/cppschema/backend/api_backend_bridge.h
+++ b/cppschema/backend/api_backend_bridge.h
@@ -24,8 +24,10 @@ void RegisterBackend(Impl* instance, const typename API::template ImplPtrs<Impl>
     auto binder = [&](auto stub, auto& impl_ref, auto member_ptr) {
         using Req = typename decltype(stub)::RequestType;
         using Res = typename decltype(stub)::ResponseType;
+        using ImplPtr = Res (Impl::*)(const Req&);
+        static_assert(std::is_same_v<Impl, std::decay_t<decltype(impl_ref)>>, "Impl type mismatch");
+        static_assert(std::is_same_v<ImplPtr, decltype(member_ptr)>, "Member pointer type mismatch");
         const char* name = decltype(stub)::name;
-
         registry.RegisterHandler(name, [instance, member_ptr](const void* rawReq) -> void* {
             const Req& typedReq = *static_cast<const Req*>(rawReq);
             Res result = (instance->*member_ptr)(typedReq);

--- a/cppschema/common/BUILD.bazel
+++ b/cppschema/common/BUILD.bazel
@@ -8,3 +8,8 @@ cc_library(
     name = "visitor_macros",
     hdrs = ["visitor_macros.h"],
 )
+
+cc_library(
+    name = "types",
+    hdrs = ["types.h"],
+)

--- a/cppschema/common/types.h
+++ b/cppschema/common/types.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// The sentinel struct representing a C++ `void` type in JavaScript.
+// Since `void` cannot be used in references, we use this type in APIs which has no arg, or
+// does not return a value.
+struct VoidType {};

--- a/cppschema/common/types.h
+++ b/cppschema/common/types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// The sentinel struct representing a C++ `void` type in JavaScript.
+// This sentinel struct represents a C++ `void` type with an empty object JavaScript.
 // Since `void` cannot be used in references, we use this type in APIs which has no arg, or
 // does not return a value.
 struct VoidType {};

--- a/cppschema/wasm/BUILD.bazel
+++ b/cppschema/wasm/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
         "js_converter_inl.h",
     ],
     deps = [
+        "//cppschema/common:types",
         "//cppschema/common:visitor_macros",
     ],
 )

--- a/example/MODULE.bazel
+++ b/example/MODULE.bazel
@@ -5,7 +5,6 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "aspect_rules_js", version = "2.9.2")
-bazel_dep(name = "aspect_rules_jest", version = "0.24.3")
 
 bazel_dep(name = "cppschema")
 local_path_override(

--- a/example/MODULE.bazel.lock
+++ b/example/MODULE.bazel.lock
@@ -11,19 +11,13 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.3/MODULE.bazel": "e4529e12d8cd5b828e2b5960d07d3ec032541740d419d7d5b859cabbf5b056f9",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.2/MODULE.bazel": "30dfabbfae0139b1f0036e01c201dd4c0167da3017f0b7ef3820d78e07622989",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.2/source.json": "89d8e5d7088ae33972733099b756dae71e1647ae684ab50b26adfa853c506d01",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.7/MODULE.bazel": "491f8681205e31bb57892d67442ce448cda4f472a8e6b3dc062865e29a64f89c",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
-    "https://bcr.bazel.build/modules/aspect_rules_jest/0.24.3/MODULE.bazel": "afbea085483cdc8a014cef6d2ee44793aeb4e9fec95f030f7c0cb35bf624abaf",
-    "https://bcr.bazel.build/modules/aspect_rules_jest/0.24.3/source.json": "d81b26aed4f566a9e099e8ccfc1d6be909f5047b01a94e237425403efe229b53",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.42.0/MODULE.bazel": "f19e6b4a16f77f8cf3728eac1f60dbfd8e043517fd4f4dbf17a75a6c50936d62",
-    "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.9.2/MODULE.bazel": "93fd5b85e6e912fb0712cbab453c43271d4ea33a093f84fd587638fbc9f8c145",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.9.2/source.json": "4bff7c03ab387b60deb15649ba575688e62f2a71a7544cbc7a660b19ec473808",
-    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.2.8/MODULE.bazel": "aa975a83e72bcaac62ee61ab12b788ea324a1d05c4aab28aadb202f647881679",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -138,7 +132,6 @@
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
-    "https://bcr.bazel.build/modules/rules_nodejs/6.2.0/MODULE.bazel": "ec27907f55eb34705adb4e8257952162a2d4c3ed0f0b3b4c3c1aad1fac7be35e",
     "https://bcr.bazel.build/modules/rules_nodejs/6.3.2/MODULE.bazel": "42e8d5254b6135f890fecca7c8d7f95a7d27a45f8275b276f66ec337767530ef",
     "https://bcr.bazel.build/modules/rules_nodejs/6.3.3/MODULE.bazel": "b66eadebd10f1f1b25f52f95ab5213a57e82c37c3f656fcd9a57ad04d2264ce7",
     "https://bcr.bazel.build/modules/rules_nodejs/6.3.3/source.json": "45bd343155bdfed2543f0e39b80ff3f6840efc31975da4b5795797f4c94147ad",
@@ -161,8 +154,7 @@
     "https://bcr.bazel.build/modules/rules_python/1.3.0/source.json": "25932f917cd279c7baefa6cb1d3fa8750a7a29de522024449b19af6eab51f4a0",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
-    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
-    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/source.json": "4757bd277fe1567763991c4425b483477bb82e35e777a56fd846eb5cceda324a",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
@@ -188,7 +180,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "rMBIK7DPPVC12axuIqNWal/MCs8NwAQsEoJq9EB/fDM=",
+        "usagesDigest": "TQSuPERI87Z4Alo1eOWeUR3NGo5f3txcCOd4tpsGXmw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -198,7 +190,6 @@
             "attributes": {
               "deps": {
                 "aspect_rules_js": "2.9.2",
-                "aspect_rules_jest": "0.24.3",
                 "aspect_tools_telemetry": "0.3.3"
               }
             }

--- a/example/graph_api.h
+++ b/example/graph_api.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cppschema/apispec/api_framework.h"
+#include "cppschema/common/types.h"
 #include "cppschema/common/visitor_macros.h"
 
 namespace graph {
@@ -16,8 +17,10 @@ struct GraphApi {
     cppschema::ApiStub<AddNodeRequest, std::string> addNode;
     // Delete a node by id, returns if successfully deleted.
     cppschema::ApiStub<std::string, bool> deleteNode;
+    // Clears all data.
+    cppschema::ApiStub<VoidType, VoidType> clearGraph;
 
-    DEFINE_API_VISITOR_FUNCTION(addNode, deleteNode);
+    DEFINE_API_VISITOR_FUNCTION(addNode, deleteNode, clearGraph);
 };
 
 }  // namespace graph

--- a/example/graph_backend.cpp
+++ b/example/graph_backend.cpp
@@ -27,6 +27,12 @@ class GraphApiImpl : public cppschema::ApiBackend<GraphApi> {
         return false;
     }
 
+    VoidType clearGraphImpl(const VoidType&) {
+        node_storage_.clear();
+        std::cout << "[Backend] Cleared all nodes." << std::endl;
+        return VoidType{};
+    }
+
  private:
     int32_t id_counter_ = 1000;
     std::map<std::string, std::string> node_storage_;
@@ -37,6 +43,7 @@ static __attribute__((constructor)) void RegisterGraphApiBackend() {
     GraphApi::ImplPtrs<GraphApiImpl> ptrs = {
         .addNode = &GraphApiImpl::addNodeImpl,
         .deleteNode = &GraphApiImpl::deleteNodeImpl,
+        .clearGraph = &GraphApiImpl::clearGraphImpl,
     };
     RegisterBackend<GraphApi, GraphApiImpl>(impl, ptrs);
 }

--- a/example/graph_jslib.test.mjs
+++ b/example/graph_jslib.test.mjs
@@ -33,10 +33,13 @@ test('WASM Graph Library Test', async (t) => {
     assert.equal(typeof nodeId, 'string', "Node ID should be a string");
     assert.ok(nodeId.length > 0, "Node ID should be a non-empty string");
 
-    const deleteOk1 = assertRpcOkAndGetPayload(graph.deleteNode(nodeId));
-    assert.strictEqual(deleteOk1, true, "Node should be deleted successfully");
+    const deleteDone1 = assertRpcOkAndGetPayload(graph.deleteNode(nodeId));
+    assert.strictEqual(deleteDone1, true, "Node should be deleted successfully");
 
-    const deleteOk2 = assertRpcOkAndGetPayload(graph.deleteNode(nodeId));
-    assert.strictEqual(deleteOk2, false, "Deleting the same node again should return false");
+    const deleteDone2 = assertRpcOkAndGetPayload(graph.deleteNode(nodeId));
+    assert.strictEqual(deleteDone2, false, "Deleting the same node again should return false");
+
+    const clearResult = assertRpcOkAndGetPayload(graph.clearGraph({}));
+    assert.deepEqual(clearResult, {}, "clearGraph should return null (VoidType)");
   });
 });

--- a/example/jest.config.mjs
+++ b/example/jest.config.mjs
@@ -1,4 +1,0 @@
-export default {
-  testEnvironment: "node",
-  testMatch: ["**/*.test.mjs", "**/*.test.js"],
-};


### PR DESCRIPTION
Use a sentinel struct to represent C++ void type.
APIs can use empty args and return empty, to emulate void.